### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Deploy to Amazon ECS
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/amine-akrout/bank_deposit_prediction/security/code-scanning/1](https://github.com/amine-akrout/bank_deposit_prediction/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow to restrict the GITHUB_TOKEN permissions. The best way is to add the block at the workflow root (top-level, before `jobs:`), so it applies to all jobs unless overridden. In this case, the workflow only needs to read repository contents (for actions/checkout), so set `contents: read`. Edit `.github/workflows/aws.yml` by inserting the following block after the `name:` and before `on:`:

```yaml
permissions:
  contents: read
```

No additional imports, methods, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
